### PR TITLE
Artisan command for key generation  was reversed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/antonioribeiro/tests-watcher-starter.git
 cd tests-watcher-starter
 composer install
 cp .env.example .example
-php artisan generate:key
+php artisan key:generate
 ## create your database and configure your .env
 php artisan migrate
 ## configure NGINX or Apache


### PR DESCRIPTION
The command `php artisan generate:key` command returns a CommandNotFoundException. Command is corrected to `php artisan key:generate`.